### PR TITLE
Fix: add missing runtime dependencies (pandas, click)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ numpy
 pylatex
 pyyaml
 wheel
+pandas
+click


### PR DESCRIPTION
Osdag imports and uses `pandas` and `click` at runtime
(CLI execution and result handling), but these packages
are missing from requirements.txt.

This PR adds them as explicit dependencies so that
`pip install -r requirements.txt` works in a clean environment.
